### PR TITLE
Fix legacy support being initialized on modern servers

### DIFF
--- a/hook/src/main/resources/plugin.yml
+++ b/hook/src/main/resources/plugin.yml
@@ -1,6 +1,7 @@
 name: PaperMakeHook
 version: '${version}'
 main: com.rikonardo.papermake.hook.PaperMakeHook
+api-version: 1.13
 commands:
   pmake:
     name: PaperMake


### PR DESCRIPTION
Sets the hook's API version to 1.13 so modern servers don't have to initialize legacy support. This has no effect on legacy servers as this property was only introduced in 1.13.