### PR TITLE
Fix the wrong artifact being used when using paperweight userdev

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ## Features
 - **Development server with IDE integration ✅**
 - **Gradle Shadow plugin compatibility ✅**
-- **In-game plugin auto-reload on gradle "build" and "shadowJar" tasks ✅**
+- **In-game plugin auto-reload on Gradle's "build", "shadowJar", and "reobfJar" tasks ✅**
 - **Working breakpoints in your plugin code and libraries ✅**
 - **Development server console right in IDE ✅**
 - **Useful in-game commands ✅**

--- a/src/main/kotlin/com/rikonardo/papermake/tasks/PostBuildTask.kt
+++ b/src/main/kotlin/com/rikonardo/papermake/tasks/PostBuildTask.kt
@@ -24,10 +24,10 @@ open class PostBuildTask : DefaultTask() {
         var artifacts = setOf<File>()
         for (task in artifactTasks) {
             val files = project.tasks.findByName(task)?.outputs?.files?.files
-            if (files.isNullOrEmpty())
-                continue
-            artifacts = files
-            break
+            if (!files.isNullOrEmpty()) {
+                artifacts = files
+                break
+            }
         }
         if (artifacts.isEmpty()) {
             throw IllegalStateException("No artifacts found")

--- a/src/main/kotlin/com/rikonardo/papermake/tasks/PostBuildTask.kt
+++ b/src/main/kotlin/com/rikonardo/papermake/tasks/PostBuildTask.kt
@@ -2,9 +2,14 @@ package com.rikonardo.papermake.tasks
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
+import java.io.File
 import kotlin.random.Random
 
 open class PostBuildTask : DefaultTask() {
+
+    // The tasks to try to get artifacts from, in order.
+    private val artifactTasks = arrayOf("reobfJar", "shadowJar", "jar")
+
     private val dir = project.buildDir.resolve("papermake")
     private val buildDir = dir.resolve("build")
     private val trigger = buildDir.resolve("reload.list")
@@ -16,12 +21,17 @@ open class PostBuildTask : DefaultTask() {
 
     @TaskAction
     fun execute() {
-        val jar = project.tasks.findByName("jar")?.outputs?.files?.files
-        val shadow = project.tasks.findByName("shadowJar")?.outputs?.files?.files
-
-        val artifacts =
-            if (shadow != null && shadow.isNotEmpty()) shadow else (if (jar != null && jar.isNotEmpty()) jar else null)
-                ?: throw IllegalStateException("No artifacts found")
+        var artifacts = setOf<File>()
+        for (task in artifactTasks) {
+            val files = project.tasks.findByName(task)?.outputs?.files?.files
+            if (files.isNullOrEmpty())
+                continue
+            artifacts = files
+            break
+        }
+        if (artifacts.isEmpty()) {
+            throw IllegalStateException("No artifacts found")
+        }
 
         if (plugins.exists()) plugins.deleteRecursively()
         plugins.mkdirs()


### PR DESCRIPTION
When using [paperweight](https://github.com/PaperMC/paperweight), it needs to remap Mojang's mappings to Spigot's, and it returns it's own file. The current system only checks for the `shadowJar` and `jar` tasks' files which is before the remapping is done, meaning PaperMake loads the incorrect jar into the server.

This slightly refactors how the artifacts are retrieved and adds the `reobfJar` task to the list.