### PR TITLE
Add flag to OP all players that join

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ You can use next optional properties to configure environment:
 | `pmake.dir`      | Path to the directory where dev server will be launched, can be relative to project directory. By default, server runs in `build/papermake/run`.            |
 | `pmake.server`   | Path to custom server jar, can be relative to run directory. If specified, `pmake.version`, `pmake.mojmap` and `pmake.noverify` properties will be ignored. |
 | `pmake.gui`      | When `true`, removes default "-nogui" server arg that prevents server gui window from appearing.                                                            |
+| `pmake.autoop`   | When `true`, *all* players that join the server will be OPed.                                                                                               |
 | `pmake.args`     | Additional arguments for development server. Fore example, `-o=false` will disable online-mode.                                                             |
 
 Properties are specified with `-P` prefix. Here's an example:

--- a/hook/src/main/kotlin/com/rikonardo/papermake/hook/PaperMakeHook.kt
+++ b/hook/src/main/kotlin/com/rikonardo/papermake/hook/PaperMakeHook.kt
@@ -1,6 +1,7 @@
 package com.rikonardo.papermake.hook
 
 import com.rikonardo.papermake.hook.commands.PMakeCommand
+import com.rikonardo.papermake.hook.listeners.PlayerJoinListener
 import org.bukkit.Bukkit
 import org.bukkit.plugin.java.JavaPlugin
 import java.io.File
@@ -19,6 +20,12 @@ class PaperMakeHook : JavaPlugin() {
             Bukkit.getPluginManager().disablePlugin(this)
             return
         }
+
+        if (System.getProperty("pmake.autoop", "false").toBoolean()) {
+            logger.info("Auto-OP enabled, all players that join will be OPed!")
+            Bukkit.getPluginManager().registerEvents(PlayerJoinListener(), this)
+        }
+
         getCommand("pmake")!!.apply {
             executor = PMakeCommand
             tabCompleter = PMakeCommand

--- a/hook/src/main/kotlin/com/rikonardo/papermake/hook/PaperMakeHook.kt
+++ b/hook/src/main/kotlin/com/rikonardo/papermake/hook/PaperMakeHook.kt
@@ -21,7 +21,7 @@ class PaperMakeHook : JavaPlugin() {
             return
         }
 
-        if (System.getProperty("pmake.autoop", "false").toBoolean()) {
+        if (System.getProperty("papermake.autoop", "false").toBoolean()) {
             logger.info("Auto-OP enabled, all players that join will be OPed!")
             Bukkit.getPluginManager().registerEvents(PlayerJoinListener, this)
         }

--- a/hook/src/main/kotlin/com/rikonardo/papermake/hook/PaperMakeHook.kt
+++ b/hook/src/main/kotlin/com/rikonardo/papermake/hook/PaperMakeHook.kt
@@ -23,7 +23,7 @@ class PaperMakeHook : JavaPlugin() {
 
         if (System.getProperty("pmake.autoop", "false").toBoolean()) {
             logger.info("Auto-OP enabled, all players that join will be OPed!")
-            Bukkit.getPluginManager().registerEvents(PlayerJoinListener(), this)
+            Bukkit.getPluginManager().registerEvents(PlayerJoinListener(this), this)
         }
 
         getCommand("pmake")!!.apply {

--- a/hook/src/main/kotlin/com/rikonardo/papermake/hook/PaperMakeHook.kt
+++ b/hook/src/main/kotlin/com/rikonardo/papermake/hook/PaperMakeHook.kt
@@ -23,7 +23,7 @@ class PaperMakeHook : JavaPlugin() {
 
         if (System.getProperty("pmake.autoop", "false").toBoolean()) {
             logger.info("Auto-OP enabled, all players that join will be OPed!")
-            Bukkit.getPluginManager().registerEvents(PlayerJoinListener(this), this)
+            Bukkit.getPluginManager().registerEvents(PlayerJoinListener, this)
         }
 
         getCommand("pmake")!!.apply {

--- a/hook/src/main/kotlin/com/rikonardo/papermake/hook/listeners/PlayerJoinListener.kt
+++ b/hook/src/main/kotlin/com/rikonardo/papermake/hook/listeners/PlayerJoinListener.kt
@@ -1,20 +1,17 @@
 package com.rikonardo.papermake.hook.listeners
 
+import com.rikonardo.papermake.hook.plugin
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerJoinEvent
-import org.bukkit.plugin.java.JavaPlugin
 
-class PlayerJoinListener(private val plugin: JavaPlugin) : Listener {
-
+object PlayerJoinListener : Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     fun onJoin(e: PlayerJoinEvent) {
-        val player = e.player;
-        if (player.isOp)
-            return;
+        val player = e.player
+        if (player.isOp) return
         player.isOp = true
         plugin.logger.info("OPed " + player.name + "!")
     }
-
 }

--- a/hook/src/main/kotlin/com/rikonardo/papermake/hook/listeners/PlayerJoinListener.kt
+++ b/hook/src/main/kotlin/com/rikonardo/papermake/hook/listeners/PlayerJoinListener.kt
@@ -4,12 +4,14 @@ import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerJoinEvent
+import org.bukkit.plugin.java.JavaPlugin
 
-class PlayerJoinListener : Listener {
+class PlayerJoinListener(private val plugin: JavaPlugin) : Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     fun onJoin(e: PlayerJoinEvent) {
         e.player.isOp = true
+        plugin.logger.info("OPed " + e.player.name + "!")
     }
 
 }

--- a/hook/src/main/kotlin/com/rikonardo/papermake/hook/listeners/PlayerJoinListener.kt
+++ b/hook/src/main/kotlin/com/rikonardo/papermake/hook/listeners/PlayerJoinListener.kt
@@ -10,8 +10,11 @@ class PlayerJoinListener(private val plugin: JavaPlugin) : Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     fun onJoin(e: PlayerJoinEvent) {
-        e.player.isOp = true
-        plugin.logger.info("OPed " + e.player.name + "!")
+        val player = e.player;
+        if (player.isOp)
+            return;
+        player.isOp = true
+        plugin.logger.info("OPed " + player.name + "!")
     }
 
 }

--- a/hook/src/main/kotlin/com/rikonardo/papermake/hook/listeners/PlayerJoinListener.kt
+++ b/hook/src/main/kotlin/com/rikonardo/papermake/hook/listeners/PlayerJoinListener.kt
@@ -1,0 +1,15 @@
+package com.rikonardo.papermake.hook.listeners
+
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerJoinEvent
+
+class PlayerJoinListener : Listener {
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    fun onJoin(e: PlayerJoinEvent) {
+        e.player.isOp = true
+    }
+
+}

--- a/src/main/kotlin/com/rikonardo/papermake/tasks/DevServerTask.kt
+++ b/src/main/kotlin/com/rikonardo/papermake/tasks/DevServerTask.kt
@@ -75,7 +75,7 @@ open class DevServerTask : JavaExec() {
             }
             devServer.systemProperty("com.mojang.eula.agree", "true")
             devServer.systemProperty("papermake.watch", buildDir.canonicalPath)
-            devServer.systemProperty("pmake.autoop", project.hasProperty("pmake.autoop") && project.property("pmake.autoop").toString().toBoolean())
+            devServer.systemProperty("papermake.autoop", project.hasProperty("pmake.autoop") && project.property("pmake.autoop").toString().toBoolean())
             devServer.classpath(server)
             devServer.standardInput = System.`in`
             devServer.workingDir = runDir

--- a/src/main/kotlin/com/rikonardo/papermake/tasks/DevServerTask.kt
+++ b/src/main/kotlin/com/rikonardo/papermake/tasks/DevServerTask.kt
@@ -75,6 +75,7 @@ open class DevServerTask : JavaExec() {
             }
             devServer.systemProperty("com.mojang.eula.agree", "true")
             devServer.systemProperty("papermake.watch", buildDir.canonicalPath)
+            devServer.systemProperty("pmake.autoop", project.hasProperty("pmake.autoop") && project.property("pmake.autoop").toString().toBoolean())
             devServer.classpath(server)
             devServer.standardInput = System.`in`
             devServer.workingDir = runDir


### PR DESCRIPTION
Assuming you aren't testing anything permission related, it can be a little tedious having to manually OP yourself to use commands; whether it's commands for your plugin or setting the time to day.

This adds a flag to OP all players that join automatically.

I didn't see a clear way to pass flags to the server outside of the args flag which I don't think is super fitting in this case, so I've added a fixed set property call.

If there's something you'd like implemented in a different way, or not at all, please let me know.