### PR TITLE
Allow GameRules to be set with a flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,17 +57,18 @@ Run `devServer` task (from `papermake` category) to start development server.
 
 You can use next optional properties to configure environment:
 
-| Property         | Description                                                                                                                                                 |
-|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `pmake.version`  | Minecraft version of development server. Can be any version, which has available paper release. By default, PaperMake would use latest release.             |
-| `pmake.mojmap`   | If `true`, downloads Paper version that uses Mojang's deobfuscation mappings.                                                                               |
-| `pmake.noverify` | If `true`, checksum verification of the downloaded Paper server is not performed.                                                                           |
-| `pmake.port`     | Port for development server. Default port: `25565`. Note, that if port unavailable, PaperMake would try to use port, incremented by 1 (e.g. `25566`).       |
-| `pmake.dir`      | Path to the directory where dev server will be launched, can be relative to project directory. By default, server runs in `build/papermake/run`.            |
-| `pmake.server`   | Path to custom server jar, can be relative to run directory. If specified, `pmake.version`, `pmake.mojmap` and `pmake.noverify` properties will be ignored. |
-| `pmake.gui`      | When `true`, removes default "-nogui" server arg that prevents server gui window from appearing.                                                            |
-| `pmake.autoop`   | When `true`, *all* players that join the server will be OPed.                                                                                               |
-| `pmake.args`     | Additional arguments for development server. Fore example, `-o=false` will disable online-mode.                                                             |
+| Property          | Description                                                                                                                                                 |
+|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `pmake.version`   | Minecraft version of development server. Can be any version, which has available paper release. By default, PaperMake would use latest release.             |
+| `pmake.mojmap`    | If `true`, downloads Paper version that uses Mojang's deobfuscation mappings.                                                                               |
+| `pmake.noverify`  | If `true`, checksum verification of the downloaded Paper server is not performed.                                                                           |
+| `pmake.port`      | Port for development server. Default port: `25565`. Note, that if port unavailable, PaperMake would try to use port, incremented by 1 (e.g. `25566`).       |
+| `pmake.dir`       | Path to the directory where dev server will be launched, can be relative to project directory. By default, server runs in `build/papermake/run`.            |
+| `pmake.server`    | Path to custom server jar, can be relative to run directory. If specified, `pmake.version`, `pmake.mojmap` and `pmake.noverify` properties will be ignored. |
+| `pmake.gui`       | When `true`, removes default "-nogui" server arg that prevents server gui window from appearing.                                                            |
+| `pmake.autoop`    | When `true`, *all* players that join the server will be OPed.                                                                                               |
+| `pmake.args`      | Additional arguments for development server. Fore example, `-o=false` will disable online-mode.                                                             |
+| `pmake.gamerules` | GameRules to set for all worlds, seperated by commas (`,`). Example: `"doDaylightCycle=false,doWeatherCycle=false"`                                         |
 
 Properties are specified with `-P` prefix. Here's an example:
 ```shell

--- a/hook/src/main/kotlin/com/rikonardo/papermake/hook/PaperMakeHook.kt
+++ b/hook/src/main/kotlin/com/rikonardo/papermake/hook/PaperMakeHook.kt
@@ -26,6 +26,21 @@ class PaperMakeHook : JavaPlugin() {
             Bukkit.getPluginManager().registerEvents(PlayerJoinListener, this)
         }
 
+        val rawGameRules = System.getProperty("papermake.gamerules")
+        if (rawGameRules != null) {
+            val gameRules = rawGameRules.split(",")
+            for (gameRule in gameRules) {
+                val args = gameRule.split("=")
+                for (world in Bukkit.getWorlds()) {
+                    if (world.setGameRuleValue(args[0], args[1])) {
+                        logger.info("Set GameRule '${args[0]}' to '${args[1]}' in world ${world.name}.")
+                    } else {
+                        logger.warning("Failed to set GameRule '${args[0]}' to '${args[1]}' in world ${world.name}!")
+                    }
+                }
+            }
+        }
+
         getCommand("pmake")!!.apply {
             executor = PMakeCommand
             tabCompleter = PMakeCommand

--- a/src/main/kotlin/com/rikonardo/papermake/tasks/DevServerTask.kt
+++ b/src/main/kotlin/com/rikonardo/papermake/tasks/DevServerTask.kt
@@ -76,6 +76,9 @@ open class DevServerTask : JavaExec() {
             devServer.systemProperty("com.mojang.eula.agree", "true")
             devServer.systemProperty("papermake.watch", buildDir.canonicalPath)
             devServer.systemProperty("papermake.autoop", project.hasProperty("pmake.autoop") && project.property("pmake.autoop").toString().toBoolean())
+            if (project.hasProperty("pmake.gamerules")) {
+                devServer.systemProperty("papermake.gamerules", project.property("pmake.gamerules").toString())
+            }
             devServer.classpath(server)
             devServer.standardInput = System.`in`
             devServer.workingDir = runDir


### PR DESCRIPTION
Adds a new flag, `pmake.gamerules`, to allow game rules to be set ahead of time. This is especially useful for disabling things like the daylight cycle and weather that tend to get in the way of testing things.