### PR TITLE
Update Paper API usage to v3

### DIFF
--- a/src/main/kotlin/com/rikonardo/papermake/tasks/DevServerTask.kt
+++ b/src/main/kotlin/com/rikonardo/papermake/tasks/DevServerTask.kt
@@ -167,7 +167,7 @@ open class DevServerTask : JavaExec() {
             } else {
                 try {
                     val paper =
-                        Yok.get("https://api.papermc.io/v2/projects/paper").body.json["versions"].list!!.map { it.string!! }
+                        Yok.get("https://fill.papermc.io/v3/projects/paper").body.json["versions"].list!!.map { it.string!! }
                     for (i in paper.lastIndex downTo 0) {
                         version = paper[i]
                         if (serversDir.resolve("$type/$version.jar").exists()) {
@@ -204,18 +204,21 @@ open class DevServerTask : JavaExec() {
         private fun getPaperArtifact(version: String, mojmap: Boolean = false): Pair<String, String>? {
             try {
                 val builds =
-                    Yok.get("https://api.papermc.io/v2/projects/paper/versions/$version/builds").body.json["builds"].list!!
+                    Yok.get("https://fill.papermc.io/v3/projects/paper/versions/$version/builds").body.json.list!!
                 if (builds.isEmpty()) return null
-                val latest = builds.last()
-                val buildNumber: Int = latest["build"].int!!
-                val downloadArtifact = if (mojmap) "mojang-mappings" else "application"
-                val artifactName = latest["downloads"][downloadArtifact]["name"].string!!
-                val artifactHash = latest["downloads"][downloadArtifact]["sha256"].string!!
+                val latest = builds.first()
+                val downloads = latest["downloads"]
+                val selected = if (mojmap && downloads.has("server:mojang")) {
+                    downloads["server:mojang"]
+                } else {
+                    downloads["server:default"]
+                }
+                val artifactHash = selected["checksums"]["sha256"].string!!
                 return Pair(
-                    "https://api.papermc.io/v2/projects/paper/versions/$version/builds/$buildNumber/downloads/$artifactName",
+                    selected["url"].string!!,
                     artifactHash
                 )
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 return null
             }
         }


### PR DESCRIPTION
Paper released v3 of their API some time ago, and are now in the process of deprecating the v2 API. This includes no longer adding new game versions to the v2 API. This means PaperMake could not download 26.1 versions or newer. This updates the API usage to v3 while maintaining all the same behaviour as before.