### PR TITLE
Fix the nogui flag not being applied to version 26.1+

### DIFF
--- a/src/main/kotlin/com/rikonardo/papermake/tasks/DevServerTask.kt
+++ b/src/main/kotlin/com/rikonardo/papermake/tasks/DevServerTask.kt
@@ -33,9 +33,11 @@ open class DevServerTask : JavaExec() {
             set(value) {
                 field = value
                 val split = value.split(".")
+                majorVersion = split[0].toInt()
                 minorVersion = split[1].toInt()
                 patchVersion = if (split.size >= 3) split[2].toInt() else 0
             }
+        private var majorVersion = -1
         private var minorVersion = -1
         private var patchVersion = -1
 
@@ -78,7 +80,7 @@ open class DevServerTask : JavaExec() {
             properties.store(propertiesFile.outputStream(), "Minecraft server properties")
             installHook()
             val args = mutableListOf<String>()
-            if ((minorVersion >= 15 && (minorVersion != 15 || patchVersion > 1)) && (!project.hasProperty("pmake.gui") || !project.property("pmake.gui").toString().toBoolean()))
+            if ((majorVersion > 1 || (majorVersion == 1 && (minorVersion >= 15 && (minorVersion != 15 || patchVersion > 1)))) && (!project.hasProperty("pmake.gui") || !project.property("pmake.gui").toString().toBoolean()))
                 args.add("-nogui")
             val port = freePort(
                 if (project.hasProperty("pmake.port")) project.property("pmake.port").toString().toInt()


### PR DESCRIPTION
The old logic ignored the major version and only checked that the minor/patch was >= `15.1`. With the new versioning scheme, we now have `26.1.2` for example, which to the old logic would be `1.2` and would not get the `-nogui` flag. This PR tweaks the logic so any version where the major is > 1 will get the `-nogui` flag.